### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ This wrapper allows access to all the dimensions and languages available on Duck
 | `url` | "https://api.wit.ai/message?q=hi" | `{"value":"https://api.wit.ai/message?q=hi","domain":"api.wit.ai"}` |
 | `volume` | "4 gallons" | `{"value":4,"type":"value","unit":"gallon"}` |
 
+## Reference Docs
+https://docs.contour.so/treble-ai/pyduckling/getting-started
 
 ## Changelog
 Please see our [CHANGELOG](https://github.com/treble-ai/pyduckling/blob/master/CHANGELOG.md) file to learn more about our new features and improvements.


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!